### PR TITLE
Set stretch mode in updateViewSize

### DIFF
--- a/src/image.android.ts
+++ b/src/image.android.ts
@@ -378,6 +378,10 @@ export class Img extends ImageBase {
         } else {
             draweeView.setAspectRatio(0);
         }
+
+        if (this.stretch) {
+            draweeView.setScaleType(getScaleTypeAndroid(this.stretch));
+        }
     }
 
     // public initNativeView(): void {
@@ -991,6 +995,36 @@ function getScaleType(scaleType: ScaleType) {
                 return com.facebook.drawee.drawable.ScalingUtils.ScaleType.FIT_XY;
             case ScaleType.FocusCrop:
                 return com.facebook.drawee.drawable.ScalingUtils.ScaleType.FOCUS_CROP;
+            default:
+                break;
+        }
+    }
+
+    return null;
+}
+
+function getScaleTypeAndroid(scaleType: ScaleType) {
+    if (isString(scaleType)) {
+        switch (scaleType) {
+            case ScaleType.Center:
+                return android.widget.ImageView.ScaleType.CENTER;
+            case ScaleType.AspectFill:
+            case ScaleType.CenterCrop:
+                return android.widget.ImageView.ScaleType.CENTER_CROP;
+            case ScaleType.CenterInside:
+                return android.widget.ImageView.ScaleType.CENTER_INSIDE;
+            case ScaleType.FitCenter:
+            case ScaleType.AspectFit:
+                return android.widget.ImageView.ScaleType.FIT_CENTER;
+            case ScaleType.FitEnd:
+                return android.widget.ImageView.ScaleType.FIT_END;
+            case ScaleType.FitStart:
+                return android.widget.ImageView.ScaleType.FIT_START;
+            case ScaleType.Fill:
+            case ScaleType.FitXY:
+                return android.widget.ImageView.ScaleType.FIT_XY;
+            case ScaleType.FocusCrop:
+                return android.widget.ImageView.ScaleType.CENTER_CROP;
             default:
                 break;
         }


### PR DESCRIPTION
Should fix https://github.com/nativescript-community/ui-image/issues/37 for Android.

~~I can't currently build nor test iOS, so would be good to know if https://github.com/nativescript-community/ui-image/issues/37 even happens in iOS at all or not.~~ A friend helped me test in iOS and this bug is not present there, it's only in Android.

I am not sure if this is the best solution, I see that the scale types used in the plug-in come from `com.facebook.drawee.drawable.ScalingUtils.ScaleType` but when using those in `setScaleType`, I was getting a "wrong parameter" error from Android, only using the types from `android.widget.ImageView.ScaleType` worked.