### PR TITLE
Use Fresco hierarchy to update scale size when using ImageSource

### DIFF
--- a/src/image.android.ts
+++ b/src/image.android.ts
@@ -380,7 +380,7 @@ export class Img extends ImageBase {
         }
 
         if (this.stretch) {
-            draweeView.setScaleType(getScaleTypeAndroid(this.stretch));
+            draweeView.getHierarchy().setActualImageScaleType(getScaleType(this.stretch));
         }
     }
 
@@ -995,36 +995,6 @@ function getScaleType(scaleType: ScaleType) {
                 return com.facebook.drawee.drawable.ScalingUtils.ScaleType.FIT_XY;
             case ScaleType.FocusCrop:
                 return com.facebook.drawee.drawable.ScalingUtils.ScaleType.FOCUS_CROP;
-            default:
-                break;
-        }
-    }
-
-    return null;
-}
-
-function getScaleTypeAndroid(scaleType: ScaleType) {
-    if (isString(scaleType)) {
-        switch (scaleType) {
-            case ScaleType.Center:
-                return android.widget.ImageView.ScaleType.CENTER;
-            case ScaleType.AspectFill:
-            case ScaleType.CenterCrop:
-                return android.widget.ImageView.ScaleType.CENTER_CROP;
-            case ScaleType.CenterInside:
-                return android.widget.ImageView.ScaleType.CENTER_INSIDE;
-            case ScaleType.FitCenter:
-            case ScaleType.AspectFit:
-                return android.widget.ImageView.ScaleType.FIT_CENTER;
-            case ScaleType.FitEnd:
-                return android.widget.ImageView.ScaleType.FIT_END;
-            case ScaleType.FitStart:
-                return android.widget.ImageView.ScaleType.FIT_START;
-            case ScaleType.Fill:
-            case ScaleType.FitXY:
-                return android.widget.ImageView.ScaleType.FIT_XY;
-            case ScaleType.FocusCrop:
-                return android.widget.ImageView.ScaleType.CENTER_CROP;
             default:
                 break;
         }


### PR DESCRIPTION
Should fix #37 in a better way, using Fresco instead of Android classes.