### PR TITLE
Ability to add headers to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,13 @@ Number value used as the downsampled width of the imageModule drawable.
 <@nativescript-community/ui-image:Img decodeHeight="100"/>
 ```
 
+- **headers** (iOS only)
+
+Object that defines custom request headers to be sent with the image download request.
+
+```xml
+<@nativescript-community/ui-image:Img headers="{Authorization: 'bearer abcdefghijk'}"/>
+```
 
 - **progressiveRenderingEnabled**
 

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -439,6 +439,13 @@ Number value used as the downsampled width of the imageModule drawable.
 <@nativescript-community/ui-image:Img decodeHeight="100"/>
 ```
 
+- **headers** (iOS only)
+
+Object that defines custom request headers to be sent with the image download request.
+
+```xml
+<@nativescript-community/ui-image:Img headers="{Authorization: 'bearer abcdefghijk'}"/>
+```
 
 - **progressiveRenderingEnabled**
 

--- a/packages/image/blueprint.md
+++ b/packages/image/blueprint.md
@@ -372,6 +372,13 @@ Number value used as the downsampled width of the imageModule drawable.
 <@nativescript-community/ui-image:Img decodeHeight="100"/>
 ```
 
+- **headers** (iOS only)
+
+Object that defines custom request headers to be sent with the image download request.
+
+```xml
+<@nativescript-community/ui-image:Img headers="{Authorization: 'bearer abcdefghijk'}"/>
+```
 
 - **progressiveRenderingEnabled**
 

--- a/src/image/index-common.ts
+++ b/src/image/index-common.ts
@@ -156,6 +156,7 @@ export class EventData implements IEventData {
 export type Stretch = 'none' | 'fill' | 'aspectFill' | 'aspectFit';
 
 export const srcProperty = new Property<ImageBase, string | ImageSource | ImageAsset>({ name: 'src' });
+export const headersProperty = new Property<ImageBase, Map<string, string>>({ name: 'headers' });
 export const lowerResSrcProperty = new Property<ImageBase, string>({ name: 'lowerResSrc' });
 export const placeholderImageUriProperty = new Property<ImageBase, string>({ name: 'placeholderImageUri' });
 export const failureImageUriProperty = new Property<ImageBase, string>({ name: 'failureImageUri' });
@@ -394,6 +395,7 @@ export abstract class ImageBase extends View {
     }
 }
 srcProperty.register(ImageBase);
+headersProperty.register(ImageBase);
 lowerResSrcProperty.register(ImageBase);
 placeholderImageUriProperty.register(ImageBase);
 failureImageUriProperty.register(ImageBase);

--- a/src/image/index.d.ts
+++ b/src/image/index.d.ts
@@ -195,6 +195,11 @@ export class Img extends View {
     decodeHeight: number;
 
     /**
+     * IOS: add custom headers to the image download request
+     */
+    headers: Record<string, string>;
+
+    /**
      * IOS: if you want to show animated images you need to set this to true
      */
     animatedImageView: boolean;

--- a/src/image/index.ios.ts
+++ b/src/image/index.ios.ts
@@ -13,6 +13,7 @@ import {
     SrcType,
     Stretch,
     failureImageUriProperty,
+    headersProperty,
     imageRotationProperty,
     placeholderImageUriProperty,
     srcProperty,
@@ -274,6 +275,7 @@ export class Img extends ImageBase {
     mCacheKey: string;
 
     contextOptions = null;
+    headers: Map<string, string> = new Map<string, string>();
 
     get cacheKey() {
         return this.mCacheKey;
@@ -520,6 +522,20 @@ export class Img extends ImageBase {
                         context.setValueForKey(value, k);
                     });
                 }
+
+                if (this.headers.size > 0) {
+                    const requestModifier = SDWebImageDownloaderRequestModifier.requestModifierWithBlock((request: NSURLRequest): NSURLRequest => {
+                        const newRequest = request.mutableCopy() as NSMutableURLRequest;
+                        this.headers.forEach((value, key) => {
+                            newRequest.addValueForHTTPHeaderField(value, key);
+                        });
+
+                        return newRequest.copy();
+                    });
+
+                    context.setValueForKey(requestModifier, SDWebImageContextDownloadRequestModifier);
+                }
+
                 this.mCacheKey = SDWebImageManager.sharedManager.cacheKeyForURLContext(uri, context);
                 this.nativeImageViewProtected.sd_setImageWithURLPlaceholderImageOptionsContextProgressCompleted(
                     uri,
@@ -549,6 +565,14 @@ export class Img extends ImageBase {
     [placeholderImageUriProperty.setNative]() {
         // this.placeholderImage = this.getUIImage(this.placeholderImageUri);
         // this.initImage();
+    }
+
+    [headersProperty.getDefault](): Map<string, string> {
+        return new Map<string, string>();
+    }
+
+    [headersProperty.setNative](value) {
+        this.headers = value;
     }
 
     [failureImageUriProperty.setNative]() {


### PR DESCRIPTION
This adds a headers prop that allows a user to specify custom headers to be sent with the image download request. It is especially useful for sending authentication headers.

I added this so that I could migrate from nativescript-image-cache-it which has this functionality but has recently begun to crash our app. I only implemented for iOS since I'm not very familiar with Android development